### PR TITLE
Fixing model load unit test failures

### DIFF
--- a/deepqlearning/Training_Example.ipynb
+++ b/deepqlearning/Training_Example.ipynb
@@ -19,7 +19,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "5601c4f1",
    "metadata": {},
    "outputs": [
@@ -47,7 +47,10 @@
     "    sys.path.append('src')\n",
     "\n",
     "# Output directory for models, results, and plots\n",
-    "model_dir = Path('models')\n",
+    "if 'OUTPUT_DIR' in os.environ:\n",
+    "    model_dir = Path(os.environ['OUTPUT_DIR'], 'models')\n",
+    "else:\n",
+    "    model_dir = Path('models')\n",
     "model_dir.mkdir(exist_ok=True)\n",
     "\n",
     "from environment import FinancialLifeEnv, FinancialLifeEnvGenerator\n",

--- a/src/life_model/tests/test_notebooks.py
+++ b/src/life_model/tests/test_notebooks.py
@@ -193,6 +193,9 @@ class TestTrainingExampleNotebook(JupyterNotebookTestBase):
         """Test that the Training_Example.ipynb notebook executes without errors."""
         os.environ['NUM_EPISODES'] = '10'  # Set a shorter episode count for testing
         os.environ['OUTPUT_DIR'] = tempfile.mkdtemp()  # Use a temp directory for outputs
+        # Disable weight-only loading to avoid issues with model saving
+        # https://docs.pytorch.org/docs/stable/notes/serialization.html#torch-load-with-weights-only-true
+        os.environ['TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD'] = '1'
         self._execute_notebook()
 
 

--- a/src/life_model/tests/test_notebooks.py
+++ b/src/life_model/tests/test_notebooks.py
@@ -192,6 +192,7 @@ class TestTrainingExampleNotebook(JupyterNotebookTestBase):
     def test_notebook_execution(self):
         """Test that the Training_Example.ipynb notebook executes without errors."""
         os.environ['NUM_EPISODES'] = '10'  # Set a shorter episode count for testing
+        os.environ['OUTPUT_DIR'] = tempfile.gettempdir()  # Use a temp directory for outputs
         self._execute_notebook()
 
 

--- a/src/life_model/tests/test_notebooks.py
+++ b/src/life_model/tests/test_notebooks.py
@@ -192,7 +192,7 @@ class TestTrainingExampleNotebook(JupyterNotebookTestBase):
     def test_notebook_execution(self):
         """Test that the Training_Example.ipynb notebook executes without errors."""
         os.environ['NUM_EPISODES'] = '10'  # Set a shorter episode count for testing
-        os.environ['OUTPUT_DIR'] = tempfile.gettempdir()  # Use a temp directory for outputs
+        os.environ['OUTPUT_DIR'] = tempfile.mkdtemp()  # Use a temp directory for outputs
         self._execute_notebook()
 
 


### PR DESCRIPTION
Fixing an issue where tox is trying to write out the same file for two different versions of python, causing a loading issue.
Also, disabling weights_only load for unit tests, as mentioned here (see below). This is OK because the loaded model is generated within the unit test and not subject to user input.
https://docs.pytorch.org/docs/stable/notes/serialization.html#torch-load-with-weights-only-true